### PR TITLE
Remove redundant call

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -114,5 +114,5 @@ buildRules = do
 
 main :: IO ()
 main = do
-  let shOpts = forwardOptions $ shakeOptions { shakeVerbosity = Chatty}
+  let shOpts = shakeOptions { shakeVerbosity = Chatty}
   shakeArgsForward shOpts buildRules


### PR DESCRIPTION
Shake already does this:
https://hackage.haskell.org/package/shake-0.18.4/docs/src/Development.Shake.Forward.html#shakeArgsForward