### PR TITLE
Added Support for Atom Feed

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -58,10 +58,8 @@ data IndexInfo =
     { posts :: [Post]
     } deriving (Generic, Show, FromJSON, ToJSON)
 
--- | Data for tags
-data Tag =
-  Tag { tag :: String
-      } deriving (Generic, Show, FromJSON, ToJSON, Binary, Eq, Ord)
+type Tag = String
+
 -- | Data for a blog post
 data Post =
     Post { title       :: String
@@ -137,9 +135,9 @@ buildFeed posts = do
   now <- liftIO getCurrentTime
   let atomData =
         AtomData
-          { title = "<site-title-here>"
-          , domain = "https://<your-domain-here>"
-          , author = "<author-name-here>"
+          { title = siteTitle siteMeta
+          , domain = baseUrl siteMeta
+          , author = siteAuthor siteMeta
           , posts = mkAtomPost <$> posts
           , currentTime = toIsoDate now
           , atomUrl = "/atom.xml"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Main where
 
@@ -76,12 +76,12 @@ data Post =
     deriving (Generic, Eq, Ord, Show, FromJSON, ToJSON, Binary)
 
 data AtomData =
-  AtomData { title :: String
-           , domain :: String
-           , author :: String
-           , posts :: [Post]
-           , currentTime :: String
-           , atomUrl :: String } deriving (Generic, ToJSON, Eq, Ord, Show)
+  AtomData { title        :: String
+           , domain       :: String
+           , author       :: String
+           , posts        :: [Post]
+           , currentTime  :: String
+           , atomUrl      :: String } deriving (Generic, ToJSON, Eq, Ord, Show)
 
 -- | given a list of posts this will build a table of contents
 buildIndex :: [Post] -> Action ()

--- a/docs/atom.xml
+++ b/docs/atom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>&lt;site-title-here&gt;</title>
+    <link href="https://&lt;your-domain-here&gt;/atom.xml" rel="self" type="application/rss+xml" />
+  <updated>2020-04-08T20:00:SZ</updated>
+  <author>
+      <name>&lt;author-name-here&gt;</name>
+  </author>
+  <id>https://&lt;your-domain-here&gt;/</id>
+
+  <entry>
+      <title>Sample Post</title>
+      <link href="https://&lt;your-domain-here&gt;posts/sample-post.html"/>
+      <id>https://&lt;your-domain-here&gt;posts/sample-post.html</id>
+      <updated>2019-01-01T00:00:SZ</updated>
+      <category term="slick"/>
+      <category term="site"/>
+      <summary>My first blog post using slick</summary>
+      <content type="html"><![CDATA[<p>Welcome to your first blog post!</p>]]></content>
+  </entry>
+</feed>

--- a/docs/posts/sample-post.html
+++ b/docs/posts/sample-post.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"> 
+<html lang="en">
 <head profile="http://www.w3.org/2005/10/profile">
     <meta charset="UTF-8">
     <meta name="description" content="My Slick Site">
@@ -50,6 +50,10 @@
             <span class="date">Jan 1, 2019</span>
             <br>
             <div class="metadata">
+            </div>
+            <div class="tags">
+              <span class="tag slick">slick</span>
+              <span class="tag site">site</span>
             </div>
         </div>
     </div>

--- a/package.yaml
+++ b/package.yaml
@@ -34,3 +34,4 @@ executables:
     - lens
     - aeson
     - lens-aeson
+    - time

--- a/site/posts/sample-post.md
+++ b/site/posts/sample-post.md
@@ -2,7 +2,7 @@
 title: "Sample Post"
 author: Me
 date: Jan 1, 2019
-tags: [slick, site]
+tags: [{ tag: slick }, { tag: site }]
 description: My first blog post using slick
 image: code.jpg
 ---

--- a/site/posts/sample-post.md
+++ b/site/posts/sample-post.md
@@ -2,7 +2,7 @@
 title: "Sample Post"
 author: Me
 date: Jan 1, 2019
-tags: [{ tag: slick }, { tag: site }]
+tags: [slick, site]
 description: My first blog post using slick
 image: code.jpg
 ---

--- a/site/templates/atom.xml
+++ b/site/templates/atom.xml
@@ -15,7 +15,7 @@
       <id>{{domain}}{{url}}</id>
       <updated>{{date}}</updated>
       {{#tags}}
-      <category term="{{tag}}"/>
+      <category term="{{.}}"/>
       {{/tags}}
       <summary>{{description}}</summary>
       <content type="html"><![CDATA[{{{content}}}]]></content>

--- a/site/templates/atom.xml
+++ b/site/templates/atom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>{{title}}</title>
+    <link href="{{domain}}{{atomUrl}}" rel="self" type="application/rss+xml" />
+  <updated>{{currentTime}}</updated>
+  <author>
+      <name>{{author}}</name>
+  </author>
+  <id>{{domain}}/</id>
+
+  {{#posts}}
+  <entry>
+      <title>{{title}}</title>
+      <link href="{{domain}}{{url}}"/>
+      <id>{{domain}}{{url}}</id>
+      <updated>{{date}}</updated>
+      {{#tags}}
+      <category term="{{tag}}"/>
+      {{/tags}}
+      <summary>{{description}}</summary>
+      <content type="html"><![CDATA[{{{content}}}]]></content>
+  </entry>
+  {{/posts}}
+</feed>

--- a/site/templates/post.html
+++ b/site/templates/post.html
@@ -35,7 +35,7 @@
             </div>
             <div class="tags">
               {{#tags}}
-              <span class="tag {{tag}}">{{tag}}</span>
+              <span class="tag {{.}}">{{.}}</span>
               {{/tags}}
             </div>
         </div>

--- a/site/templates/post.html
+++ b/site/templates/post.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"> 
+<html lang="en">
 <head profile="http://www.w3.org/2005/10/profile">
     <meta charset="UTF-8">
     <meta name="description" content="{{siteTitle}}">
@@ -32,6 +32,11 @@
             <span class="date">{{date}}</span>
             <br>
             <div class="metadata">
+            </div>
+            <div class="tags">
+              {{#tags}}
+              <span class="tag {{tag}}">{{tag}}</span>
+              {{/tags}}
             </div>
         </div>
     </div>

--- a/slick-template.cabal
+++ b/slick-template.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 69b04ccda50b02c400102b2bc38e78fae6edac00a6ec3000193ab41742161262
+-- hash: 99608593197be2adb4aa74b31a94255716eef02a03cb55c4477261cee7cf3fc2
 
 name:           slick-template
 version:        0.1.0.0
@@ -43,5 +43,6 @@ executable build-site
     , shake
     , slick
     , text
+    , time
     , unordered-containers
   default-language: Haskell2010


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/ChrisPenner/slick-template/issues/7)

High level changes:
- Builder `buildFeed` for `atom.xml` file
- Build step that generates atom.xml from posts
- `AtomData` for top level feed info
- Pulled in `time` package
- Added `DuplicateRecordFields` language pragma
- Added feed template `/site/templates/atom.xml`
- Added `tags` and `description` field to `Post` record
- Added `Tag` data structure
- Rendered tags in sample post

Most of these changes were based off of Chris Penner's implementation of an Atom feed generator on his site.